### PR TITLE
reset status is changed from Interview controller

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,6 @@
 class InterviewsController < ApplicationController
-  before_action :set_interview, only: [:show, :next_question, :feedback]
   skip_before_action :authenticate_user!
+  before_action :set_interview, only: [:show, :next_question, :feedback]
 
   def index
   end
@@ -21,7 +21,6 @@ class InterviewsController < ApplicationController
     @interview.user_id = @user_id
     @questions = Question.all.sample(10).uniq
     if @interview.save
-      reset_session
       @interview.number_of_questions.times do
         @interview_question = InterviewQuestion.new(interview_id: @interview.id, question_id: @questions.pop.id)
         @interview_question.save

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -14,4 +14,3 @@
   <%= "Thank you for your commitment!" %>
   <%= link_to "Submit", feedback_interview_path(@interview)%>
 <% end %>
-<%raise%>


### PR DESCRIPTION
The reset session from the Interview controller is removed. Now it wont through you out of the session after you enter the answer.